### PR TITLE
Update asyncio implementation

### DIFF
--- a/actionpack/procedure.py
+++ b/actionpack/procedure.py
@@ -45,7 +45,7 @@ class Procedure(Generic[Name, Outcome]):
         for action in self.actions:
             actions.append(action.aperform(should_raise=should_raise))
 
-        return await asyncio.gather(*actions)
+        return await asyncio.gather(*actions, return_exceptions=not(should_raise))
 
     async def aio_execute(
         self,

--- a/actionpack/procedure.py
+++ b/actionpack/procedure.py
@@ -40,16 +40,21 @@ class Procedure(Generic[Name, Outcome]):
         self,
         should_raise: bool = False
     ) -> Iterator[Result[Outcome]]:
+        # for action in self.actions:
+        #     logger.debug(f"running action {action}")
+        #     ret = await action.aperform(should_raise=should_raise)
+        #     yield ret
+        actions = []
         for action in self.actions:
-            logger.debug(f"running action {action}")
-            ret = await action.aperform(should_raise=should_raise)
-            yield ret
+            actions.append(action.aperform(should_raise=should_raise))
+        ret = await asyncio.gather(*actions)
+        return ret
 
     async def aio_execute(
         self,
         should_raise: bool = False
     ) -> Iterator[Result[Outcome]]:
-        val = [a async for a in self.aio_gen(should_raise)]
+        val = await self.aio_gen(should_raise)
         logger.debug(f"aio_execute {val}")
         return val
 

--- a/actionpack/procedure.py
+++ b/actionpack/procedure.py
@@ -40,15 +40,12 @@ class Procedure(Generic[Name, Outcome]):
         self,
         should_raise: bool = False
     ) -> Iterator[Result[Outcome]]:
-        # for action in self.actions:
-        #     logger.debug(f"running action {action}")
-        #     ret = await action.aperform(should_raise=should_raise)
-        #     yield ret
         actions = []
+        # We only create coroutines here -- we're not running them until the `gather`.
         for action in self.actions:
             actions.append(action.aperform(should_raise=should_raise))
-        ret = await asyncio.gather(*actions)
-        return ret
+
+        return await asyncio.gather(*actions)
 
     async def aio_execute(
         self,

--- a/tests/actionpack/test_procedure.py
+++ b/tests/actionpack/test_procedure.py
@@ -176,32 +176,6 @@ class KeyedProcedureTest(TestCase):
         self.assertIn('success', results.keys())
         self.assertIn('failure', results.keys())
 
-    def test_benchmark_asyncio_vs_threads(self):
-        import timeit
-        import logging
-        import sys
-
-        logger = logging.getLogger(__name__)
-        logger.setLevel(logging.INFO)
-        stream_handler = logging.StreamHandler()
-        logger.addHandler(stream_handler)
-
-        start_time = timeit.default_timer()
-        KeyedProcedure((success, failure)).execute(max_workers=0, synchronously=False)
-        async_results = timeit.default_timer() - start_time
-
-        start_time = timeit.default_timer()
-        KeyedProcedure((success, failure)).execute(synchronously=False)
-        thread_results = timeit.default_timer() - start_time
-
-        start_time = timeit.default_timer()
-        KeyedProcedure((success, failure)).execute(max_workers=0, synchronously=False)
-        synch_results = timeit.default_timer() - start_time
-
-        logger.info(f"\nAsync results: {async_results}")
-        logger.info(f"\nThreaded results: {thread_results}")
-        logger.info(f"\nSynchronous results: {synch_results}")
-
     def test_can_create_KeyedProcedure_from_Actions_named_using_any_scriptable_type(self):
         action1 = FakeAction[int, str]()
         action2 = FakeAction[bool, str](instruction_provider=raise_failure)

--- a/tests/actionpack/test_procedure.py
+++ b/tests/actionpack/test_procedure.py
@@ -176,6 +176,32 @@ class KeyedProcedureTest(TestCase):
         self.assertIn('success', results.keys())
         self.assertIn('failure', results.keys())
 
+    def test_benchmark_asyncio_vs_threads(self):
+        import timeit
+        import logging
+        import sys
+
+        logger = logging.getLogger(__name__)
+        logger.setLevel(logging.INFO)
+        stream_handler = logging.StreamHandler()
+        logger.addHandler(stream_handler)
+
+        start_time = timeit.default_timer()
+        KeyedProcedure((success, failure)).execute(max_workers=0, synchronously=False)
+        async_results = timeit.default_timer() - start_time
+
+        start_time = timeit.default_timer()
+        KeyedProcedure((success, failure)).execute(synchronously=False)
+        thread_results = timeit.default_timer() - start_time
+
+        start_time = timeit.default_timer()
+        KeyedProcedure((success, failure)).execute(max_workers=0, synchronously=False)
+        synch_results = timeit.default_timer() - start_time
+
+        logger.info(f"\nAsync results: {async_results}")
+        logger.info(f"\nThreaded results: {thread_results}")
+        logger.info(f"\nSynchronous results: {synch_results}")
+
     def test_can_create_KeyedProcedure_from_Actions_named_using_any_scriptable_type(self):
         action1 = FakeAction[int, str]()
         action2 = FakeAction[bool, str](instruction_provider=raise_failure)


### PR DESCRIPTION
I noticed that the prior implementation of asyncio appears to await every call once at a time -- using `asyncio.gather` allows for us to schedule tasks concurrently instead of imperatively. Quick benchmarking appeared to show a subtle difference in timing, but I'm sure that will be more substantial against proper IO-based tasks instead of mocks.